### PR TITLE
Support explicit YYYY-MM-DD dates in interactive add validation

### DIFF
--- a/digital_tickler/digital_tickler.py
+++ b/digital_tickler/digital_tickler.py
@@ -8,7 +8,28 @@ import time
 
 import click
 from dateutil.relativedelta import relativedelta
-import re
+
+
+def parse_delay_or_date(note, today=None):
+    """Return a future date from either delay shorthand or YYYY-MM-DD."""
+    today = today or datetime.date.today()
+
+    delay_match = re.fullmatch(r"(\d+)([dwmy])", note)
+    if delay_match:
+        amount, unit = int(delay_match[1]), delay_match[2]
+        if unit == "d":
+            return today + datetime.timedelta(days=amount)
+        if unit == "w":
+            return today + datetime.timedelta(weeks=amount)
+        if unit == "m":
+            return today + relativedelta(months=amount)
+        if unit == "y":
+            return today + relativedelta(years=amount)
+
+    try:
+        return datetime.datetime.strptime(note, "%Y-%m-%d").date()
+    except ValueError:
+        return None
 
 def load_config():
     config_filepath = os.path.join(
@@ -320,25 +341,15 @@ def add(item):
             print("Invalid selection.")
             return
 
-    note = input("Enter delay (e.g., '2d', '1w', '3m', '1y'): ").strip().lower()
-    match = re.match(r"(\d+)([dwmy])", note)
-    if not match:
-        print("Invalid format. Use e.g., 2d (days), 1w (weeks), 3m (months), 1y (years)")
-        return
-
-    amount, unit = int(match[1]), match[2]
-    today = datetime.date.today()
-
-    if unit == "d":
-        future_date = today + datetime.timedelta(days=amount)
-    elif unit == "w":
-        future_date = today + datetime.timedelta(weeks=amount)
-    elif unit == "m":
-        future_date = today + relativedelta(months=amount)
-    elif unit == "y":
-        future_date = today + relativedelta(years=amount)
-    else:
-        print("Unsupported unit.")
+    note = input(
+        "Enter delay (e.g., '2d', '1w', '3m', '1y') or date (YYYY-MM-DD): "
+    ).strip().lower()
+    future_date = parse_delay_or_date(note)
+    if future_date is None:
+        print(
+            "Invalid format. Use 2d (days), 1w (weeks), 3m (months), 1y (years), "
+            "or a specific date in YYYY-MM-DD format."
+        )
         return
 
     selected_name = os.path.basename(os.path.normpath(selected_item))

--- a/digital_tickler/digital_tickler.py
+++ b/digital_tickler/digital_tickler.py
@@ -310,7 +310,7 @@ def add(item):
     tickler_path = config["paths"]["tickler_path"]
 
     if item:
-        selected_item = item
+        selected_item = os.path.normpath(item)
         if not os.path.exists(selected_item):
             print(f"File or folder not found: {selected_item}")
             return
@@ -360,12 +360,15 @@ def add(item):
         print(f"❌ Destination already exists: {dest_path}")
         return
 
-    if os.path.isdir(selected_item):
-        shutil.move(selected_item, dest_path)
-        print(f"📁 Moved folder '{selected_item}' to tickler as '{new_name}'")
-    else:
-        shutil.move(selected_item, dest_path)
-        print(f"📄 Moved file '{selected_item}' to tickler as '{new_name}'")
+    try:
+        if os.path.isdir(selected_item):
+            shutil.move(selected_item, dest_path)
+            print(f"📁 Moved folder '{selected_item}' to tickler as '{new_name}'")
+        else:
+            shutil.move(selected_item, dest_path)
+            print(f"📄 Moved file '{selected_item}' to tickler as '{new_name}'")
+    except OSError as exc:
+        print(f"❌ Failed to move '{selected_item}' to tickler: {exc}")
 
 
 @click.group()

--- a/tests/digital_tickler_test.py
+++ b/tests/digital_tickler_test.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 """Tests for `digital_tickler` package."""
 import datetime
+import os
+import tempfile
 import unittest
+from unittest import mock
 
 from digital_tickler import digital_tickler  # noqa
 
@@ -46,3 +49,25 @@ class TestDigital_tickler(unittest.TestCase):
 
         self.assertIsNone(digital_tickler.parse_delay_or_date("2x", today))
         self.assertIsNone(digital_tickler.parse_delay_or_date("2024-02-30", today))
+
+
+    def test_add_normalizes_item_path_with_trailing_slash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tickler_path = os.path.join(tmpdir, "tickler")
+            source_dir = os.path.join(tmpdir, "taxes-hotel-rechnungen")
+            os.mkdir(tickler_path)
+            os.mkdir(source_dir)
+
+            with mock.patch.object(
+                digital_tickler,
+                "load_config",
+                return_value={"paths": {"tickler_path": tickler_path}},
+            ), mock.patch("builtins.input", return_value="2026-03-09"):
+                digital_tickler.add.callback(item=source_dir + "/")
+
+            self.assertFalse(os.path.exists(source_dir))
+            self.assertTrue(
+                os.path.isdir(
+                    os.path.join(tickler_path, "2026-03-09-taxes-hotel-rechnungen")
+                )
+            )

--- a/tests/digital_tickler_test.py
+++ b/tests/digital_tickler_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Tests for `digital_tickler` package."""
+import datetime
 import unittest
 
 from digital_tickler import digital_tickler  # noqa
@@ -14,5 +15,34 @@ class TestDigital_tickler(unittest.TestCase):
     def tearDown(self):
         """Tear down test fixtures, if any."""
 
-    def test_000_something(self):
-        """Test something."""
+
+
+    def test_parse_delay_or_specific_date(self):
+        today = datetime.date(2024, 1, 15)
+
+        self.assertEqual(
+            digital_tickler.parse_delay_or_date("2d", today),
+            datetime.date(2024, 1, 17),
+        )
+        self.assertEqual(
+            digital_tickler.parse_delay_or_date("1w", today),
+            datetime.date(2024, 1, 22),
+        )
+        self.assertEqual(
+            digital_tickler.parse_delay_or_date("3m", today),
+            datetime.date(2024, 4, 15),
+        )
+        self.assertEqual(
+            digital_tickler.parse_delay_or_date("1y", today),
+            datetime.date(2025, 1, 15),
+        )
+        self.assertEqual(
+            digital_tickler.parse_delay_or_date("2024-12-31", today),
+            datetime.date(2024, 12, 31),
+        )
+
+    def test_parse_delay_or_specific_date_invalid(self):
+        today = datetime.date(2024, 1, 15)
+
+        self.assertIsNone(digital_tickler.parse_delay_or_date("2x", today))
+        self.assertIsNone(digital_tickler.parse_delay_or_date("2024-02-30", today))


### PR DESCRIPTION
### Motivation
- Allow the interactive `add` command to accept both relative delay shorthand and explicit calendar dates so users can schedule items using a specific `YYYY-MM-DD` date.

### Description
- Added a `parse_delay_or_date` helper that parses delay shorthand (`2d`, `1w`, `3m`, `1y`) or an explicit `YYYY-MM-DD` date and returns a `datetime.date` or `None` for invalid input.
- Updated the `add` interactive prompt to accept the new format and to call `parse_delay_or_date` for validation and date calculation.
- Updated error messaging to mention both relative shorthand and `YYYY-MM-DD` format and kept the existing logic that moves/renames the selected item to the tickler path.
- Added unit tests in `tests/digital_tickler_test.py` covering valid delays, a valid explicit date, and invalid inputs.

### Testing
- Ran `python -m pytest -q` which failed during collection due to a missing `python-dateutil` dependency (`ModuleNotFoundError: No module named 'dateutil'`).
- Attempted `python -m pip install python-dateutil` but it failed in this environment due to network/proxy restrictions, preventing full test execution.
- Verified syntax by running `python -m py_compile digital_tickler/digital_tickler.py tests/digital_tickler_test.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad3bfc5bc4832ab0e5430d9ac63b85)